### PR TITLE
Emscripten now builds with glfw

### DIFF
--- a/backends/imgui_impl_glfw.cpp
+++ b/backends/imgui_impl_glfw.cpp
@@ -1223,6 +1223,7 @@ VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkSurfaceKHR)
 struct VkAllocationCallbacks;
 enum VkResult { VK_RESULT_MAX_ENUM = 0x7FFFFFFF };
 #endif // VULKAN_H_
+#ifndef __EMSCRIPTEN__
 extern "C" { extern GLFWAPI VkResult glfwCreateWindowSurface(VkInstance instance, GLFWwindow* window, const VkAllocationCallbacks* allocator, VkSurfaceKHR* surface); }
 static int ImGui_ImplGlfw_CreateVkSurface(ImGuiViewport* viewport, ImU64 vk_instance, const void* vk_allocator, ImU64* out_vk_surface)
 {
@@ -1233,6 +1234,7 @@ static int ImGui_ImplGlfw_CreateVkSurface(ImGuiViewport* viewport, ImU64 vk_inst
     VkResult err = glfwCreateWindowSurface((VkInstance)vk_instance, vd->Window, (const VkAllocationCallbacks*)vk_allocator, (VkSurfaceKHR*)out_vk_surface);
     return (int)err;
 }
+#endif
 #endif // GLFW_HAS_VULKAN
 
 static void ImGui_ImplGlfw_InitPlatformInterface()
@@ -1257,7 +1259,9 @@ static void ImGui_ImplGlfw_InitPlatformInterface()
     platform_io.Platform_SetWindowAlpha = ImGui_ImplGlfw_SetWindowAlpha;
 #endif
 #if GLFW_HAS_VULKAN
+#ifndef __EMSCRIPTEN__
     platform_io.Platform_CreateVkSurface = ImGui_ImplGlfw_CreateVkSurface;
+#endif
 #endif
 
     // Register main window handle (which is owned by the main application, not by us)


### PR DESCRIPTION
Building the GLFW/OpenGL3 emscripten example project throws compiler error with error message
 - "wasm-ld: error: ../imgui/libImGui.a(imgui_impl_glfw.cpp.o): undefined symbol: glfwCreateWindowSurface"
 
 This just removes the vulkan related references when building emscripten project.

